### PR TITLE
Implement pre-MVP filtering

### DIFF
--- a/backend/filter.py
+++ b/backend/filter.py
@@ -31,6 +31,7 @@ def filter_files(repo_path: str):
                 file.unlink()
     
     # Delete empty directories in reverse order
+    # Sort paths based on depth and delete children first before parents
     for dir_path in sorted(repo.rglob("*"), key=lambda p: len(p.parts), reverse=True):
         if dir_path.is_dir() and not any(dir_path.iterdir()):
             dir_path.rmdir()

--- a/backend/filter.py
+++ b/backend/filter.py
@@ -29,5 +29,10 @@ def filter_files(repo_path: str):
             # Delete non-Java files
             else:
                 file.unlink()
+    
+    # Delete empty directories in reverse order
+    for dir_path in sorted(repo.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if dir_path.is_dir() and not any(dir_path.iterdir()):
+            dir_path.rmdir()
 
     return java_files

--- a/backend/filter.py
+++ b/backend/filter.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+def filter_files(repo_path: str):
+    """
+    Filters out non-Java files from the input path.
+
+    Args:
+        repo_path (str): The path to the repository ("repos/username/repo_name")
+
+    Returns:
+        List[Path]: A list of Path objects representing Java files
+    """
+
+    repo = Path(repo_path)
+
+    # Validate input directory
+    if not repo.is_dir():
+        raise ValueError(f"{repo_path} is not a valid directory.")
+    
+    # List of Java files
+    java_files = []
+
+    # Recursively visit subdirectories
+    for file in repo.rglob("*"):
+        if file.is_file():
+            # Add Java files to list
+            if file.suffix == ".java":
+                java_files.append(file)
+            # Delete non-Java files
+            else:
+                file.unlink()
+
+    return java_files


### PR DESCRIPTION
This PR introduces the file filtering logic to remove non-Java files from the repository. The module recursively scans the provided directory, retains only Java files, and deletes non-Java files. Closes **LB-63**.

Tests still pending discussion on testing frameworks with the team.

**Objective:**
Implement utility method that removes non-Java files in place from the input directory (e.g. `repos/username/repo_name`). 

**Input:**
File path containing the source code repository (e.g. `repos/username/repo_name`)

**Output**: 
TBD. Output pending discussion with @tachille4.